### PR TITLE
index.js: different result using process.nextTick

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -176,7 +176,7 @@ function resolve (p, x) {
 
 function process (p) {
   if (p.state === PENDING) return;
-  setImmediate(() => {
+  global.process.nextTick(() => {
     let qp, handler, value;
     while(p.queue.length) {
       qp = p.queue.shift();


### PR DESCRIPTION
I'm not sure if this correct for the project but the
the result looks good.

Fidelity.resolve
Average (mean) 538.0571928071928

Bluebird.resolve
Average (mean) 457.51023976023976

Q()
Average (mean) 89.36563463964796